### PR TITLE
Main

### DIFF
--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -15,7 +15,7 @@ deployments:
       name: gpt-4o
       version: "2024-05-13"
     sku:
-      name: Standard
+      name: GlobalStandard
       capacity: 20
   - name: text-embedding-ada-002
     model:


### PR DESCRIPTION
This pull request includes a change to the `infra/ai.yaml` file to update the SKU name for the `gpt-4o` deployment.

* [`infra/ai.yaml`](diffhunk://#diff-d57f31f7cbdc3384c2e84eeda6a37ff55d3eb02c481e5c1005f9ce5825df6513L18-R18): Changed the SKU name from `Standard` to `GlobalStandard` for the `gpt-4o` deployment.